### PR TITLE
Fix chfft #15 (Fails to compile with num_complex>0.1.40)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ test = true
 
 [dependencies]
 num-traits = ">=0.0.0"
-num-complex = ">=0.0.0"
+num-complex = "<=0.1.40"
 
 [dev-dependencies]
 rand = ">=0.0.0"


### PR DESCRIPTION
Fixes  [#15](https://github.com/chalharu/chfft/issues/15).

I'd consider it a stopgap for now, since this will certainly decouple this project from upstream fixes in num(_complex), wouldn't know where to start looking for a proper fix though.
@chalharu got any pointers to find a proper fix?