### PR TITLE
Add the ability to run on no_std targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ bench = false
 test = true
 
 [dependencies]
-num-traits = ">=0.0.0"
-num-complex = ">=0.0.0"
+num-traits = { version = ">=0.0.0", default-features = false }
+num-complex = { version = ">=0.0.0", default-features = false }
 
 [dev-dependencies]
 rand = ">=0.7.0"
@@ -28,4 +28,6 @@ version=">=0.0.0"
 features=["complex"]
 
 [features]
+default = ["std"]
 docs = []
+std = ["num-traits/std", "num-complex/std"]


### PR DESCRIPTION
This should be pretty straight forward as the library already doesn't use std.  As a user, I can now depend on the crate with no default features and have it work on embedded no-std platforms