### PR TITLE
use katex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ features=["complex"]
 
 [features]
 docs = []
+
+[package.metadata.docs.rs]
+rustdoc-args = [ "--html-in-header", "katex-header.html" ]

--- a/katex-header.html
+++ b/katex-header.html
@@ -1,0 +1,20 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.css"
+    integrity="sha384-9eLZqc9ds8eNjO3TmqPeYcDj8n+Qfa4nuSiGYa6DjLNcv9BtN69ZIulL9+8CqC9Y" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.js"
+    integrity="sha384-K3vbOmF2BtaVai+Qk37uypf7VrgBubhQreNQe9aGsz9lB63dIFiQVlJbr92dw2Lx"
+    crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/contrib/auto-render.min.js"
+    integrity="sha384-kmZOZB5ObwgQnS/DuDg6TScgOiWWBiVt0plIRkZCmE6rDZGrEOQeHM5PcHi+nyqe"
+    crossorigin="anonymous"></script>
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        renderMathInElement(document.body, {
+            delimiters: [
+                { left: "$$", right: "$$", display: true },
+                { left: "\\(", right: "\\)", display: false },
+                { left: "$", right: "$", display: false },
+                { left: "\\[", right: "\\]", display: true }
+            ]
+        });
+    });
+</script>

--- a/src/cfft1d.rs
+++ b/src/cfft1d.rs
@@ -24,7 +24,6 @@ enum WorkData<T> {
 
 /// Perform a complex-to-complex one-dimensional Fourier transform
 ///
-/// <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML"></script>
 /// When X is input array and Y is output array,
 /// the forward discrete Fourier transform of the one-dimensional array is
 ///

--- a/src/cfft2d.rs
+++ b/src/cfft2d.rs
@@ -13,8 +13,6 @@ use num_traits::{cast, NumAssign};
 
 /// Perform a complex-to-complex two-dimensional Fourier transform
 ///
-/// <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML"></script>
-///
 /// # Example
 ///
 /// ```rust

--- a/src/mdct1d.rs
+++ b/src/mdct1d.rs
@@ -14,8 +14,6 @@ use num_traits::{cast, one, NumAssign};
 
 /// Perform a Modified discrete cosine transform
 ///
-/// <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML"></script>
-///
 /// # Example
 ///
 /// ```rust

--- a/src/rfft1d.rs
+++ b/src/rfft1d.rs
@@ -14,8 +14,6 @@ use num_traits::{cast, NumAssign};
 
 /// Perform a real-to-complex one-dimensional Fourier transform
 ///
-/// <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML"></script>
-///
 /// # Example
 ///
 /// ```rust


### PR DESCRIPTION
Fixes #37 

You can verify the output locally by running `RUSTDOCFLAGS="--html-in-header katex-header.html" cargo doc --no-deps --open`, as suggested in the [demo](https://docs.rs/rustdoc-katex-demo/0.1.5/rustdoc_katex_demo/)

<img width="1680" alt="Screenshot 2020-10-15 at 00 51 04" src="https://user-images.githubusercontent.com/38644266/96057365-b4643180-0e80-11eb-96a5-219ccfed02c6.png">
